### PR TITLE
Add preview/download buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Link Directory</title>
   <link rel="stylesheet" href="styles.css">
 </head>

--- a/links.json
+++ b/links.json
@@ -1,10 +1,22 @@
 [
   {
     "name": "1",
-    "url": "https://t.me/bishnoi_botz"
+    "preview": "https://t.me/bishnoi_botz",
+    "download": "https://t.me/bishnoi_botz?download=1"
   },
   {
     "name": "2",
-    "url": "https://t.me/bishnoi_botz/123"
+    "preview": "https://t.me/bishnoi_botz/123",
+    "download": "https://t.me/bishnoi_botz/123?download=1"
+  },
+  {
+    "name": "3",
+    "preview": "https://example.com/preview3",
+    "download": "https://example.com/download3"
+  },
+  {
+    "name": "4",
+    "preview": "https://example.com/preview4",
+    "download": "https://example.com/download4"
   }
 ]

--- a/script.js
+++ b/script.js
@@ -5,10 +5,25 @@ function renderList(list) {
   container.innerHTML = "";
   list.forEach(link => {
     const a = document.createElement("a");
-    a.href = link.url;
-    a.textContent = link.name;
-    a.target = "_blank";
+    const params = new URLSearchParams({
+      preview: link.preview,
+      download: link.download,
+      name: link.name
+    });
+    a.href = `view.html?${params.toString()}`;
     a.className = "link-button";
+
+    const left = document.createElement("span");
+    left.textContent = "Preview";
+    left.className = "left";
+
+    const right = document.createElement("span");
+    right.textContent = "Download";
+    right.className = "right";
+
+    a.appendChild(left);
+    a.appendChild(right);
+
     container.appendChild(a);
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,8 @@
   --container-bg: #fff;
   --button-bg: #0070f3;
   --button-bg-hover: #0059c1;
+  --preview-color: #0070f3;
+  --download-color: #e91e63;
 }
 
 body {
@@ -18,10 +20,12 @@ body.dark {
   --container-bg: #333;
   --button-bg: #3399ff;
   --button-bg-hover: #2376cc;
+  --preview-color: #3399ff;
+  --download-color: #ff4081;
 }
 
 .container {
-  max-width: 450px;
+  max-width: 600px;
   margin: 50px auto;
   padding: 20px;
   background: var(--container-bg);
@@ -66,18 +70,50 @@ body.dark {
   border: none;
 }
 
+#links-list {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+}
+
 .link-button {
-  display: block;
-  background-color: var(--button-bg);
+  display: flex;
+  background: linear-gradient(90deg, var(--preview-color) 50%, var(--download-color) 50%);
   color: white;
+  border-radius: 5px;
+  text-decoration: none;
+  overflow: hidden;
+  font-weight: bold;
+}
+
+.link-button:hover {
+  filter: brightness(1.1);
+}
+
+.link-button .left,
+.link-button .right {
+  flex: 1;
+  padding: 12px 0;
+  text-align: center;
+}
+
+#action-buttons {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+}
+
+.action-btn {
+  flex: 1;
+  background: var(--button-bg);
+  color: #fff;
   text-align: center;
   padding: 12px;
-  margin: 10px 0;
   border-radius: 5px;
   text-decoration: none;
   font-weight: bold;
 }
 
-.link-button:hover {
-  background-color: var(--button-bg-hover);
+.action-btn:hover {
+  background: var(--button-bg-hover);
 }

--- a/view.html
+++ b/view.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Link Options</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="container">
+    <div class="header">
+      <h1 id="title">Link</h1>
+    </div>
+    <div id="action-buttons">
+      <a id="preview-btn" class="action-btn" target="_blank">Preview</a>
+      <a id="download-btn" class="action-btn" target="_blank">Download</a>
+    </div>
+  </div>
+  <script src="view.js"></script>
+</body>
+</html>

--- a/view.js
+++ b/view.js
@@ -1,0 +1,9 @@
+const params = new URLSearchParams(window.location.search);
+
+document.getElementById('preview-btn').href = params.get('preview');
+document.getElementById('download-btn').href = params.get('download');
+
+const name = params.get('name');
+if (name) {
+  document.getElementById('title').textContent = name;
+}


### PR DESCRIPTION
## Summary
- add responsive viewport in index.html
- store preview and download URLs in links.json
- update link rendering to show a dual-color button
- support preview/download actions in a separate page
- style buttons in a grid layout

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684bbcd50a58832f9e2e1f7ed00d25c9