### PR TITLE
Add Telegram bot for managing site links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Daily Hantai Telegram Bot
+
+This bot lets an administrator manage the `links.json` file used by the web site.
+
+## Features
+
+- `/post` – create a new button. The bot will ask for the preview and download
+  links one by one. The new entry is appended to `links.json` with the next
+  numeric name.
+- `/edit <number>` – edit an existing button. The bot will request new preview
+  and download links for the selected entry.
+
+Only the user ID specified in the `ADMIN_ID` environment variable can use these
+commands. If `ADMIN_ID` is not set, anyone can manage the links.
+
+## Deployment
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Set environment variables:
+   - `BOT_TOKEN` – Telegram bot token.
+   - `ADMIN_ID` – your Telegram numeric user ID.
+3. Start the bot:
+   ```bash
+   npm start
+   ```
+
+The bot reads and writes `links.json` in the repository root. Deploying to
+Heroku works the same as any Node.js application.

--- a/bot.js
+++ b/bot.js
@@ -1,0 +1,97 @@
+const TelegramBot = require('node-telegram-bot-api');
+const fs = require('fs');
+const path = require('path');
+
+const TOKEN = process.env.BOT_TOKEN;
+const ADMIN_ID = process.env.ADMIN_ID; // numeric chat id
+
+if (!TOKEN) {
+  console.error('BOT_TOKEN env var not set');
+  process.exit(1);
+}
+
+const bot = new TelegramBot(TOKEN, { polling: true });
+
+const linksPath = path.join(__dirname, 'links.json');
+let links = [];
+
+function loadLinks() {
+  try {
+    const data = fs.readFileSync(linksPath);
+    links = JSON.parse(data);
+  } catch (err) {
+    links = [];
+  }
+}
+
+function saveLinks() {
+  fs.writeFileSync(linksPath, JSON.stringify(links, null, 2));
+}
+
+function nextNumber() {
+  const numbers = links.map(l => parseInt(l.name, 10)).filter(n => !isNaN(n));
+  const max = numbers.length ? Math.max(...numbers) : 0;
+  return (max + 1).toString();
+}
+
+loadLinks();
+
+const states = {}; // chatId -> {action, step, data}
+
+function isAdmin(id) {
+  return !ADMIN_ID || id.toString() === ADMIN_ID;
+}
+
+bot.onText(/\/post/, (msg) => {
+  if (!isAdmin(msg.from.id)) return;
+  const chatId = msg.chat.id;
+  const num = nextNumber();
+  states[chatId] = { action: 'post', step: 'preview', data: { name: num } };
+  bot.sendMessage(chatId, `Send preview link for button ${num}`);
+});
+
+bot.onText(/\/edit (\d+)/, (msg, match) => {
+  if (!isAdmin(msg.from.id)) return;
+  const chatId = msg.chat.id;
+  const num = match[1];
+  const existing = links.find(l => l.name === num);
+  if (!existing) {
+    bot.sendMessage(chatId, `Button ${num} not found.`);
+    return;
+  }
+  states[chatId] = { action: 'edit', step: 'preview', data: { index: links.indexOf(existing) } };
+  bot.sendMessage(chatId, `Send new preview link for button ${num}`);
+});
+
+bot.on('message', (msg) => {
+  const chatId = msg.chat.id;
+  const text = msg.text;
+  const state = states[chatId];
+  if (!state || !text) return;
+
+  if (state.action === 'post') {
+    if (state.step === 'preview') {
+      state.data.preview = text;
+      state.step = 'download';
+      bot.sendMessage(chatId, 'Send download link');
+    } else if (state.step === 'download') {
+      state.data.download = text;
+      links.push({ name: state.data.name, preview: state.data.preview, download: state.data.download });
+      saveLinks();
+      bot.sendMessage(chatId, 'Your button ready');
+      delete states[chatId];
+    }
+  } else if (state.action === 'edit') {
+    const entry = links[state.data.index];
+    if (state.step === 'preview') {
+      entry.preview = text;
+      state.step = 'download';
+      bot.sendMessage(chatId, 'Send new download link');
+    } else if (state.step === 'download') {
+      entry.download = text;
+      saveLinks();
+      bot.sendMessage(chatId, 'Button updated');
+      delete states[chatId];
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "dailyhantaii-bot",
+  "version": "1.0.0",
+  "main": "bot.js",
+  "scripts": {
+    "start": "node bot.js"
+  },
+  "dependencies": {
+    "node-telegram-bot-api": "^0.61.0"
+  }
+}


### PR DESCRIPTION
## Summary
- implement `bot.js` using node-telegram-bot-api
- store dependencies in `package.json`
- document bot usage in `README.md`

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_684c0e3d49dc832fb82b6593f09b9597