### PR TITLE
Fix site startup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,13 @@ deployed to platforms like Vercel using a Python runtime.
 
 ## Python web site
 
-The JavaScript front end has been replaced with a small Flask application. To
-serve the site locally run:
+The JavaScript front end has been replaced with a small Flask application.
+To serve the site locally run:
 
 ```bash
 python app.py
 ```
 
-The app uses the same `links.json` file and renders the list of links server
-side.
+The app uses the same `links.json` file and renders the list of links
+server side.  Set the `PORT` environment variable if your host requires a
+specific port.

--- a/app.py
+++ b/app.py
@@ -36,4 +36,6 @@ def view():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    import os
+    port = int(os.getenv('PORT', 5000))
+    app.run(host='0.0.0.0', port=port, debug=True)


### PR DESCRIPTION
## Summary
- document using `PORT` for Flask site
- allow setting `PORT` in `app.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c28e5b328832f86e2d10a3ff5da07