### PR TITLE
Switch site back to JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,13 @@ commands. If `ADMIN_ID` is not set, anyone can manage the links.
 The bot reads and writes `links.json` in the repository root. It can be
 deployed to platforms like Vercel using a Python runtime.
 
-## Python web site
+## JavaScript web site
 
-The JavaScript front end has been replaced with a small Flask application.
-To serve the site locally run:
+This repository includes a small Express server. To serve the site locally run:
 
 ```bash
-python app.py
+npm install
+npm start
 ```
 
-The app uses the same `links.json` file and renders the list of links
-server side.  Set the `PORT` environment variable if your host requires a
-specific port.
+The server reads the same `links.json` file and the client renders the list. Set the `PORT` environment variable if your host requires a specific port.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Link Directory</title>
+  <link rel="stylesheet" href="/styles.css">
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display&display=swap" rel="stylesheet">
+</head>
+<body class="dark">
+  <div class="container">
+    <div id="top-bar">
+      <div class="header">
+        <h1 class="site-title">Daily Hantai</h1>
+        <button id="menu-toggle" aria-label="Menu">&#9776;</button>
+      </div>
+      <form id="search-form" action="" method="get">
+        <input type="text" id="query" name="q" placeholder="Search links..." />
+        <button type="submit">Search</button>
+      </form>
+      <nav id="menu" class="menu">
+        <a href="https://t.me/Bishnoi_botz" class="menu-item">Telegram Channel</a>
+        <a href="https://t.me/Bishnoi_botz" class="menu-item">Instagram Videos Channel</a>
+        <a href="https://t.me/Bishnoi_botz" class="menu-item">Support</a>
+      </nav>
+    </div>
+    <div id="links-list"></div>
+  </div>
+  <script>
+    function getQueryParam(name) {
+      const url = new URL(window.location.href);
+      return url.searchParams.get(name) || '';
+    }
+
+    async function loadLinks() {
+      const res = await fetch('links.json');
+      const data = await res.json();
+      const query = getQueryParam('q').toLowerCase();
+      const listEl = document.getElementById('links-list');
+      document.getElementById('query').value = query;
+      const filtered = data
+        .filter(l => !query || (l.name && l.name.toLowerCase().includes(query)))
+        .sort((a, b) => {
+          const na = parseInt(a.name, 10) || 0;
+          const nb = parseInt(b.name, 10) || 0;
+          return nb - na;
+        });
+      for (const link of filtered) {
+        const a = document.createElement('a');
+        a.href = `view?name=${encodeURIComponent(link.name)}&preview=${encodeURIComponent(link.preview)}&download=${encodeURIComponent(link.download)}`;
+        a.className = 'link-button';
+        a.textContent = link.name;
+        listEl.appendChild(a);
+      }
+    }
+
+    loadLinks();
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "dailyhantaii-site",
+  "version": "1.0.0",
+  "description": "Web site served with Node.js",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+
+const PORT = process.env.PORT || 3000;
+
+// Serve static files from root directory
+app.use(express.static(path.join(__dirname, '.')));
+
+// Fallback to index.html
+app.get('/', (req, res) => {
+  res.sendFile(path.join(__dirname, 'index.html'));
+});
+
+app.get('/view', (req, res) => {
+  res.sendFile(path.join(__dirname, 'view.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/view.html
+++ b/view.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Link Options</title>
+  <link rel="stylesheet" href="/styles.css">
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display&display=swap" rel="stylesheet">
+</head>
+<body class="dark">
+  <div class="container">
+    <div class="header">
+      <h1 id="title">Link</h1>
+    </div>
+    <div id="action-buttons">
+      <a id="preview-btn" class="action-btn" target="_blank" href="#">Preview</a>
+      <a id="download-btn" class="action-btn" target="_blank" href="#">Download</a>
+    </div>
+  </div>
+  <script>
+    function getQueryParam(name) {
+      const url = new URL(window.location.href);
+      return url.searchParams.get(name) || '';
+    }
+
+    function init() {
+      const name = getQueryParam('name') || 'Link';
+      const preview = getQueryParam('preview');
+      const download = getQueryParam('download');
+      document.getElementById('title').textContent = name;
+      document.getElementById('preview-btn').href = preview;
+      document.getElementById('download-btn').href = download;
+    }
+
+    init();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a small Express server
- render links client-side with JavaScript
- update README instructions for the JS site

## Testing
- `node -v`
- `npm install` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_684c2abe9c3c832f8c9c261bde5c8029