### PR TITLE
Add web admin UI with basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ The server reads the same `links.json` file and the client renders the list. Set
 
 ### Admin Panel
 
-Navigate to `/admin` in your browser to view all buttons and see how many are currently listed. The page reads `links.json` and displays each entry along with the total count.
+Navigate to `/admin` in your browser to manage the list. The admin panel is protected with HTTP Basic authentication. Set the `ADMIN_USER` and `ADMIN_PASS` environment variables before starting the server. After logging in you can see the existing buttons and add new ones by providing preview and download links. New entries are appended to `links.json` automatically.

--- a/admin.html
+++ b/admin.html
@@ -11,6 +11,11 @@
     <div class="header">
       <h1>Admin Panel</h1>
     </div>
+    <form id="add-form">
+      <input type="text" id="preview" placeholder="Preview link" required>
+      <input type="text" id="download" placeholder="Download link" required>
+      <button type="submit">Add Button</button>
+    </form>
     <p id="stats"></p>
     <table id="links-table">
       <thead>
@@ -38,6 +43,50 @@
         tbody.appendChild(row);
       }
     }
+    let auth = '';
+
+    async function request(url, options = {}) {
+      if (!auth) {
+        const user = prompt('Username');
+        const pass = prompt('Password');
+        auth = 'Basic ' + btoa(`${user}:${pass}`);
+      }
+      options.headers = Object.assign({}, options.headers, {
+        'Authorization': auth,
+        'Content-Type': 'application/json'
+      });
+      const res = await fetch(url, options);
+      if (res.status === 401) {
+        auth = '';
+        alert('Auth failed');
+        throw new Error('Auth failed');
+      }
+      return res;
+    }
+
+    document.getElementById('add-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const preview = document.getElementById('preview').value.trim();
+      const download = document.getElementById('download').value.trim();
+      if (!preview || !download) return;
+      const res = await request('/api/add', {
+        method: 'POST',
+        body: JSON.stringify({ preview, download })
+      });
+      const entry = await res.json();
+      const tbody = document.querySelector('#links-table tbody');
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td>${entry.name}</td>
+        <td><a href="${entry.preview}" target="_blank">Preview</a></td>
+        <td><a href="${entry.download}" target="_blank">Download</a></td>`;
+      tbody.appendChild(row);
+      document.getElementById('preview').value = '';
+      document.getElementById('download').value = '';
+      const count = parseInt(document.getElementById('stats').textContent.split(':')[1]) || 0;
+      document.getElementById('stats').textContent = `Total buttons: ${count + 1}`;
+    });
+
     loadAdmin();
   </script>
 </body>

--- a/server.js
+++ b/server.js
@@ -1,11 +1,29 @@
 const express = require('express');
+const fs = require('fs');
 const path = require('path');
 const app = express();
 
 const PORT = process.env.PORT || 3000;
 
-// Serve static files from root directory
+const ADMIN_USER = process.env.ADMIN_USER || 'admin';
+const ADMIN_PASS = process.env.ADMIN_PASS || 'password';
+
+function basicAuth(req, res, next) {
+  const header = req.headers['authorization'] || '';
+  const token = header.split(' ')[1];
+  if (token) {
+    const decoded = Buffer.from(token, 'base64').toString();
+    const [user, pass] = decoded.split(':');
+    if (user === ADMIN_USER && pass === ADMIN_PASS) {
+      return next();
+    }
+  }
+  res.setHeader('WWW-Authenticate', 'Basic');
+  res.status(401).send('Authentication required.');
+}
+
 app.use(express.static(path.join(__dirname, '.')));
+app.use(express.json());
 
 // Fallback to index.html
 app.get('/', (req, res) => {
@@ -16,8 +34,25 @@ app.get('/view', (req, res) => {
   res.sendFile(path.join(__dirname, 'view.html'));
 });
 
-app.get('/admin', (req, res) => {
+app.get('/admin', basicAuth, (req, res) => {
   res.sendFile(path.join(__dirname, 'admin.html'));
+});
+
+app.post('/api/add', basicAuth, (req, res) => {
+  const linksPath = path.join(__dirname, 'links.json');
+  const data = JSON.parse(fs.readFileSync(linksPath, 'utf8'));
+  const numbers = data
+    .map(l => parseInt(l.name, 10))
+    .filter(n => !isNaN(n));
+  const next = numbers.length ? Math.max(...numbers) + 1 : 1;
+  const entry = {
+    name: String(next),
+    preview: req.body.preview,
+    download: req.body.download
+  };
+  data.push(entry);
+  fs.writeFileSync(linksPath, JSON.stringify(data, null, 2));
+  res.json(entry);
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- secure `/admin` page using HTTP Basic Auth
- allow admins to add new buttons from the browser
- expose `/api/add` endpoint for appending links
- document admin credentials usage

## Testing
- `node --check server.js`

------
https://chatgpt.com/codex/tasks/task_e_684eb66d76b483238f069b3aeab4e095