### PR TITLE
Fix basic auth parsing bug

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,7 +13,9 @@ function basicAuth(req, res, next) {
   const token = header.split(' ')[1];
   if (token) {
     const decoded = Buffer.from(token, 'base64').toString();
-    const [user, pass] = decoded.split(':');
+    const index = decoded.indexOf(':');
+    const user = index >= 0 ? decoded.slice(0, index) : decoded;
+    const pass = index >= 0 ? decoded.slice(index + 1) : '';
     if (user === ADMIN_USER && pass === ADMIN_PASS) {
       return next();
     }


### PR DESCRIPTION
## Summary
- fix username/password parsing for Basic auth

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: network access denied)*

------
https://chatgpt.com/codex/tasks/task_e_684f99e8a1bc8325b30c4db42526afa1