### PR TITLE
Add mongoose connection helper

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+const { MONGODB_URI } = process.env;
+
+if (!MONGODB_URI) {
+  throw new Error('MONGODB_URI environment variable not set');
+}
+
+mongoose
+  .connect(MONGODB_URI)
+  .then(() => {
+    console.log('Connected to MongoDB via mongoose');
+  })
+  .catch((err) => {
+    console.error('MongoDB connection error:', err);
+  });
+
+module.exports = mongoose.connection;
+

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "mongodb": "^5.7.0"
+    "mongodb": "^5.7.0",
+    "mongoose": "^7.6.0"
   }
 }


### PR DESCRIPTION
## Summary
- add mongoose dependency
- add `lib/mongodb.js` with connection logic using `MONGODB_URI`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684fa020b474832583dc45245c76be33