### PR TITLE
Set default MongoDB connection

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,9 @@ const app = express();
 
 const PORT = process.env.PORT || 3000;
 
-const MONGO_URL = process.env.MONGO_URL;
+// Default MongoDB connection string
+const MONGO_URL = process.env.MONGO_URL ||
+  'mongodb+srv://SITE:SITE@cluster0.oscpdgu.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0';
 let linksCollection;
 
 if (MONGO_URL) {


### PR DESCRIPTION
## Summary
- configure `server.js` with a default `MONGO_URL`

## Testing
- `npm start` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_684fa0f43afc8325b003abd920ea9603