### PR TITLE
Load admin links from API

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -46,9 +46,9 @@
       return row;
     }
 
-    async function loadAdmin() {
-      const res = await fetch('links.json');
-      const data = await res.json();
+      async function loadAdmin() {
+        const res = await fetch('/api/links');
+        const data = await res.json();
       document.getElementById('stats').textContent = `Total buttons: ${data.length}`;
       const tbody = document.querySelector('#links-table tbody');
       tbody.innerHTML = '';


### PR DESCRIPTION
## Summary
- fetch links from `/api/links` in the admin panel

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684fe24bd170832587b44838d93b12e6