### PR TITLE
Use dotenv for MongoDB URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MONGO_URL=mongodb+srv://SITE:SITE@cluster0.oscpdgu.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -8,10 +8,15 @@ This repository contains a small Express web server that serves static pages fro
    ```bash
    npm install
    ```
-2. Start the server:
+2. Copy `.env.example` to `.env` and update `MONGO_URL` with your connection string:
+   ```bash
+   cp .env.example .env
+   # edit .env to provide your credentials
+   ```
+3. Start the server:
    ```bash
    npm start
    ```
 
 Set the `PORT` environment variable if your host requires a specific port. The admin panel is protected with HTTP Basic authentication; provide `ADMIN_USER` and `ADMIN_PASS` environment variables before starting the server.
-To store data in MongoDB instead of the local JSON file, set `MONGO_URL` to a valid MongoDB connection string before starting the server.
+To store data in MongoDB instead of the local JSON file, set `MONGO_URL` in the `.env` file to a valid MongoDB connection string before starting the server.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "express": "^4.18.2",
     "mongodb": "^5.7.0",
-    "mongoose": "^7.6.0"
+    "mongoose": "^7.6.0",
+    "dotenv": "^16.3.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -5,11 +5,13 @@ const { MongoClient } = require('mongodb');
 const linksApi = require('./pages/api/links');
 const app = express();
 
+// Load environment variables from .env if present
+require('dotenv').config();
+
 const PORT = process.env.PORT || 3000;
 
-// Default MongoDB connection string
-const MONGO_URL = process.env.MONGO_URL ||
-  'mongodb+srv://SITE:SITE@cluster0.oscpdgu.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0';
+// MongoDB connection string must be supplied via environment variable
+const MONGO_URL = process.env.MONGO_URL;
 let linksCollection;
 
 if (MONGO_URL) {


### PR DESCRIPTION
## Summary
- add `.gitignore` and exclude `.env`
- load environment variables via dotenv
- include example env file
- document env setup in README
- add dotenv dependency

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684fe335c3f88325baa8265f635ef512