### PR TITLE
Add client-side stat recording

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,18 @@
       return url.searchParams.get(name) || '';
     }
 
+    async function recordStat(type) {
+      try {
+        await fetch('/api/stats/record', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ type })
+        });
+      } catch (e) {
+        console.error('Failed to record stat', e);
+      }
+    }
+
     async function loadLinks() {
       const res = await fetch('links.json');
       const data = await res.json();
@@ -50,11 +62,13 @@
         a.href = `view.html?name=${encodeURIComponent(link.name)}&preview=${encodeURIComponent(link.preview)}&download=${encodeURIComponent(link.download)}`;
         a.className = 'link-button';
         a.textContent = link.name;
+        a.addEventListener('click', () => recordStat('click'));
         listEl.appendChild(a);
       }
     }
 
     loadLinks();
+    recordStat('visit');
 
     const menuToggle = document.getElementById('menu-toggle');
     const menu = document.getElementById('menu');

--- a/view.html
+++ b/view.html
@@ -22,6 +22,18 @@
       return url.searchParams.get(name) || '';
     }
 
+    async function recordStat(type) {
+      try {
+        await fetch('/api/stats/record', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ type })
+        });
+      } catch (e) {
+        console.error('Failed to record stat', e);
+      }
+    }
+
     function init() {
       const name = getQueryParam('name') || 'Link';
       const preview = getQueryParam('preview');
@@ -29,9 +41,12 @@
       document.getElementById('title').textContent = name;
       document.getElementById('preview-btn').href = preview;
       document.getElementById('download-btn').href = download;
+      document.getElementById('preview-btn').addEventListener('click', () => recordStat('click'));
+      document.getElementById('download-btn').addEventListener('click', () => recordStat('click'));
     }
 
     init();
+    recordStat('visit');
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- record visits and clicks from `index.html`
- do the same in `view.html`

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684ff27807e48325aa9bf782fbbeef73